### PR TITLE
set currentTab after visibility is toggled on

### DIFF
--- a/src/react-modal-login.js
+++ b/src/react-modal-login.js
@@ -91,6 +91,14 @@ class ReactModalLogin extends React.Component {
    *
    */
   componentDidUpdate(prevProps, prevState) {
+    
+    /* reset currentTab after visible is toggled on */
+    if(prevProps.visible !== this.props.visible && this.state.visible){
+      this.setState({
+        currentTab: this.props.initialTab ? this.props.initialTab : "login"
+      })
+    }
+    
     /* Initialize Facebook */
     if (
       this.props.providers &&


### PR DESCRIPTION
When you toggle the visibility of the overlay, it sets currentTab to InitialTab. This is useful if you have seperate buttons for log in and sign up.